### PR TITLE
Fix find expressions that check for occurrence of a string

### DIFF
--- a/StyleScripts/line_style.py
+++ b/StyleScripts/line_style.py
@@ -76,21 +76,21 @@ def CalculateStyleCode(row):
 
 
     # Descriptive group rules
-    elif (descGroup is not None and descGroup.find("General Feature") and physicalPres <> "Edge / Limit"):
+    elif (descGroup is not None and descGroup.find("General Feature") > -1 and physicalPres <> "Edge / Limit"):
         returnVal = 23
-    elif (descGroup is not None and descGroup.find("Building") and descTerm == "Outline" and physicalPres == "Obstructing"):
+    elif (descGroup is not None and descGroup.find("Building") > -1 and descTerm == "Outline" and physicalPres == "Obstructing"):
         returnVal = 24
-    elif (descGroup is not None and descGroup.find("General Feature") and physicalPres == "Edge / Limit"):
+    elif (descGroup is not None and descGroup.find("General Feature") > -1 and physicalPres == "Edge / Limit"):
         returnVal = 25
     elif (descGroup == "Road Or Track"):
         returnVal = 26
-    elif (descGroup is not None and descGroup.find("Building") and descTerm == "Division" and physicalPres == "Obstructing"):
+    elif (descGroup is not None and descGroup.find("Building") > -1 and descTerm == "Division" and physicalPres == "Obstructing"):
         returnVal = 27
     elif (descGroup == "Inland Water"):
         returnVal = 28
-    elif (descGroup is not None and descGroup.find("General Surface") and make == "Natural"):
+    elif (descGroup is not None and descGroup.find("General Surface") > -1 and make == "Natural"):
         returnVal = 29
-    elif (descGroup is not None and descGroup.find("Building") and descTerm == "Outline" and physicalPres == "Overhead"):
+    elif (descGroup is not None and descGroup.find("Building") > -1 and descTerm == "Outline" and physicalPres == "Overhead"):
         returnVal = 30
     elif (descGroup == "Landform" and make == "Natural"):
         returnVal = 31
@@ -167,21 +167,21 @@ def CalculateStyleDescription(row):
     elif (descTerm == "Normal Tidal Limit"):
         returnVal = "Normal Tidal Limit Line"
     # Descriptive group rules
-    elif (descGroup is not None and descGroup.find("General Feature") and physicalPres <> "Edge / Limit"):
+    elif (descGroup is not None and descGroup.find("General Feature") > -1 and physicalPres <> "Edge / Limit"):
         returnVal = "Default Line"
-    elif (descGroup is not None and descGroup.find("Building") and descTerm == "Outline" and physicalPres == "Obstructing"):
+    elif (descGroup is not None and descGroup.find("Building") > -1 and descTerm == "Outline" and physicalPres == "Obstructing"):
         returnVal = "Building Outline Line"
-    elif (descGroup is not None and descGroup.find("General Feature") and physicalPres == "Edge / Limit"):
+    elif (descGroup is not None and descGroup.find("General Feature") > -1 and physicalPres == "Edge / Limit"):
         returnVal = "Edge Line"
     elif (descGroup == "Road Or Track"):
         returnVal = "Road Or Track Line"
-    elif (descGroup is not None and descGroup.find("Building") and descTerm == "Division" and physicalPres == "Obstructing"):
+    elif (descGroup is not None and descGroup.find("Building") > -1 and descTerm == "Division" and physicalPres == "Obstructing"):
         returnVal = "Building Division Line"
     elif (descGroup == "Inland Water"):
         returnVal = "Inland Water Line"
-    elif (descGroup is not None and descGroup.find("General Surface") and make == "Natural"):
+    elif (descGroup is not None and descGroup.find("General Surface") > -1 and make == "Natural"):
         returnVal = "General Surface Natural Line"
-    elif (descGroup is not None and descGroup.find("Building") and descTerm == "Outline" and physicalPres == "Overhead"):
+    elif (descGroup is not None and descGroup.find("Building") > -1 and descTerm == "Outline" and physicalPres == "Overhead"):
         returnVal = "Building Overhead Line"
     elif (descGroup == "Landform" and make == "Natural"):
         returnVal = "Landform Natural Line"

--- a/StyleScripts/pnt_style.py
+++ b/StyleScripts/pnt_style.py
@@ -34,19 +34,19 @@ def CalculateStyleCode(row):
         returnVal = 1
     elif (descTerm == "Emergency Telephone"):
         returnVal = 2
-    elif (descTerm.find("Site Of Heritage")):
+    elif (descTerm.find("Site Of Heritage") > -1):
         returnVal = 3
-    elif (descTerm.find("Culvert")):
+    elif (descTerm.find("Culvert") > -1):
         returnVal = 4
     elif (descTerm == "Positioned Nonconiferous Tree"):
         returnVal = 5
-    elif (descGroup.find("Inland Water")):
+    elif (descGroup.find("Inland Water") > -1):
         returnVal = 6
-    elif (descGroup.find("Roadside")):
+    elif (descGroup.find("Roadside") > -1):
         returnVal = 7
-    elif (descTerm.find("Overhead Construction")):
+    elif (descTerm.find("Overhead Construction") > -1):
         returnVal = 8
-    elif (descGroup.find("Rail")):
+    elif (descGroup.find("Rail") > -1):
         returnVal = 9
     elif (descTerm == "Positioned Coniferous Tree"):
         returnVal = 10
@@ -58,9 +58,9 @@ def CalculateStyleCode(row):
         returnVal = 13
     elif (descGroup == "Landform"):
         returnVal = 14
-    elif (descGroup.find("Tidal Water")):
+    elif (descGroup.find("Tidal Water") > -1):
         returnVal = 15
-    elif (descGroup.find("Structure")):
+    elif (descGroup.find("Structure") > -1):
         returnVal = 16
     else:
         returnVal = 99
@@ -88,19 +88,19 @@ def CalculateStyleDescription(row):
         returnVal = "Spot Height Point"
     elif (descTerm == "Emergency Telephone"):
         returnVal = "Emergency Telephone Point"
-    elif (descTerm.find("Site Of Heritage")):
+    elif (descTerm.find("Site Of Heritage") > -1):
         returnVal = "Site Of Heritage Point"
-    elif (descTerm.find("Culvert")):
+    elif (descTerm.find("Culvert") > -1):
         returnVal = "Culvert Point"
     elif (descTerm == "Positioned Nonconiferous Tree"):
         returnVal = "Positioned Nonconiferous Tree Point"
-    elif (descGroup.find("Inland Water")):
+    elif (descGroup.find("Inland Water") > -1):
         returnVal = "Inland Water Point"
-    elif (descGroup.find("Roadside")):
+    elif (descGroup.find("Roadside") > -1):
         returnVal = "Roadside Point"
-    elif (descTerm.find("Overhead Construction")):
+    elif (descTerm.find("Overhead Construction") > -1):
         returnVal = "Overhead Construction Point"
-    elif (descGroup.find("Rail")):
+    elif (descGroup.find("Rail") > -1):
         returnVal = "Rail Point"
     elif (descTerm == "Positioned Coniferous Tree"):
         returnVal = "Positioned Coniferous Tree Point"
@@ -112,9 +112,9 @@ def CalculateStyleDescription(row):
         returnVal = "Historic Point"
     elif (descGroup == "Landform"):
         returnVal = "Landform Point"
-    elif (descGroup.find("Tidal Water")):
+    elif (descGroup.find("Tidal Water") > -1):
         returnVal = "Tidal Water Point"
-    elif (descGroup.find("Structure")):
+    elif (descGroup.find("Structure") > -1):
         returnVal = "Structure Point"
     else:
         returnVal = "Unclassified"


### PR DESCRIPTION
The find expressions in `line_style.py` where missing the `> -1` check. Without it the expression was only truthy if the position of the substring is `> 0`. I think the intention is for the find expression to simply test if the substring occurs at any position in the string being searched (as is the case in the other style code and description functions).


BTW I'm hoping to use the logic in `StyleScripts` within [Astuntechnology/Loader](https://github.com/AstunTechnology/Loader). I assume that's OK given this project is licensed as Apache v2? Very happy to give attribution.